### PR TITLE
Fix for getDate/getTimestamp change in RollupDao.java after upgrade to C* 3.0

### DIFF
--- a/src/main/java/com/datastax/meters/dao/RollupDao.java
+++ b/src/main/java/com/datastax/meters/dao/RollupDao.java
@@ -80,7 +80,7 @@ public class RollupDao {
 		Rollup t = new Rollup();
 
 		t.setDeviceID(row.getString("device_id"));
-		t.setMetricDay(row.getDate("metric_day"));
+		t.setMetricDay(row.getTimestamp("metric_day"));
 		t.setMetricName(row.getString("metric_name"));
 		t.setMetricAvg(row.getDecimal("metric_avg"));
 		t.setMetricMin(row.getDecimal("metric_min"));


### PR DESCRIPTION
This is just a simple fix that got left out in RollupDao.java after the driver got bumped to 3.0
